### PR TITLE
Fix "Per App profiles not working on Android 13"

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -38,7 +38,7 @@ set(THIS_LINK_FLAGS
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     target_link_libraries(dfps PRIVATE c++_static dl)
     list(APPEND THIS_COMPILE_FLAGS -O3 -fvisibility=hidden -fvisibility-inlines-hidden -flto)
-    list(APPEND THIS_LINK_FLAGS -static -O3 -fvisibility=hidden -fvisibility-inlines-hidden -flto -Wl,--strip-all)
+    list(APPEND THIS_LINK_FLAGS -static -O3 -fvisibility=hidden -fvisibility-inlines-hidden -flto -Wl,--icf=all,-O3,--lto-O3,--strip-all)
 elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
     list(APPEND THIS_COMPILE_FLAGS -fsanitize=address -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
     list(APPEND THIS_LINK_FLAGS -fsanitize=address)

--- a/source/modules/dynamic_fps.cpp
+++ b/source/modules/dynamic_fps.cpp
@@ -297,7 +297,7 @@ void DynamicFps::SwitchRefreshRate(int hz) {
 }
 
 void DynamicFps::NotifyRefreshRate(const std::string_view &hz) {
-    int fd = open(notifyPath_.c_str(), O_WRONLY | O_NONBLOCK | O_CLOEXEC | O_CREAT | O_TRUNC);
+    int fd = open(notifyPath_.c_str(), O_WRONLY | O_NONBLOCK | O_CLOEXEC | O_CREAT | O_TRUNC, 0644);
     if (fd > 0) {
         WriteSysfsFile(fd, hz);
         close(fd);

--- a/source/modules/topapp_monitor.cpp
+++ b/source/modules/topapp_monitor.cpp
@@ -33,7 +33,7 @@ void TopappMonitor::Start(void) {
     if(GetOSVersion() >= 13) {
         std::thread android13([this](){
             pthread_setname_np(pthread_self(),"Android13Worker");
-            SPDLOG_INFO("Android13Worker: GetOSVer{}",GetOSVersion());
+            SPDLOG_INFO("Android13Worker: GetOSVer: {}",GetOSVersion());
             while(true)
             {
                 ATRACE_SCOPE(GetTopAppName);

--- a/source/modules/topapp_monitor.cpp
+++ b/source/modules/topapp_monitor.cpp
@@ -39,7 +39,8 @@ void TopappMonitor::Start(void) {
                 ATRACE_SCOPE(GetTopAppName);
                 auto pkgName = GetTopAppNameDumpsys();
                 if (pkgName.empty()) {
-                    return;
+                    sleep(1);
+                    continue;
                 }
                 if (pkgName != prevPkgName_) {
                     prevPkgName_ = pkgName;


### PR DESCRIPTION
This fixed #7 and parse more optimization flags to the linker

Since Android 13, we can't monitor cgroups' changing by inotify.  So I create a new thread to monitor top app. This is not the best way to fix it but works for me.

The optimization flags comes from @asto18089 's idea. It is better to parst `-fuse-ld=lld` to clang, but we don't need it in NDK environment.